### PR TITLE
APP-13575: Update launchdarkly-server-sdk.gemspec

### DIFF
--- a/launchdarkly-server-sdk.gemspec
+++ b/launchdarkly-server-sdk.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.files         = FileList["lib/**/*", "README.md", "LICENSE.txt"]
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
+  spec.required_ruby_version = ">= 2.6.0"
 
   spec.add_development_dependency "aws-sdk-dynamodb", "~> 1.57"
   spec.add_development_dependency "bundler", "2.2.33"

--- a/launchdarkly-server-sdk.gemspec
+++ b/launchdarkly-server-sdk.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |spec|
   spec.files         = FileList["lib/**/*", "README.md", "LICENSE.txt"]
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.required_ruby_version = ">= 2.7.0"
 
   spec.add_development_dependency "aws-sdk-dynamodb", "~> 1.57"
   spec.add_development_dependency "bundler", "2.2.33"


### PR DESCRIPTION
APP-13575: Remove Ruby 2.7 requirement so our app can use this.


